### PR TITLE
Fix/blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stylelint-8-point-grid
 [![Build Status](https://travis-ci.org/dcrtantuco/stylelint-8-point-grid.svg?branch=master)](https://travis-ci.org/dcrtantuco/stylelint-8-point-grid)
 
-Validates any defined `height`, `width`, `padding` and `margin`
+Validates any defined `margin`, `padding`, `height`, and `width`
 
 ![](demo.png)
 
@@ -32,13 +32,6 @@ Update .stylelintrc or stylelint config in `package.json`
 ```
 
 ## Extending the config
-### base (default: 8)
-- value used for divisibility checking
-### ignore (default: [ ])
-- array of properties to be excluded from divisibility checking
-- supported values: `height`, `width`, `padding`, `margin`
-### whitelist (default: [ ])
-- array of px values to be excluded from divisibility checking
 ```js
 // .stylelintrc
 {
@@ -48,14 +41,42 @@ Update .stylelintrc or stylelint config in `package.json`
   "rules": {
     "plugin/8-point-grid": {
       "base": 4,
-      "whitelist": ["2px", "1px"]
+      "whitelist": ["2px", "1px"],
       "ignore": ["width", "height"]
     }
   }
 }
 ```
 
----
+### base (default: 8)
+value used for divisibility checking
+
+### whitelist
+array of px values to be excluded from divisibility checking
+
+### ignore
+array of css properties to be excluded from divisibility checking
+
+supported values:
+- margin
+- margin-top
+- margin-bottom
+- margin-left
+- margin-right
+
+- padding
+- padding-top
+- padding-bottom
+- padding-left
+- padding-right
+
+- height
+- min-height
+- max-height
+
+- width
+- min-width
+- max-width
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -7,29 +7,57 @@ const rules = {
     base: 8
   }
 }
-const blacklist = ['margin', 'padding', 'height', 'width']
+
+const blacklist = [
+  'margin',
+  'margin-top',
+  'margin-bottom',
+  'margin-left',
+  'margin-right',
+
+  'padding',
+  'padding-top',
+  'padding-bottom',
+  'padding-left',
+  'padding-right',
+
+  'height',
+  'min-height',
+  'max-height',
+
+  'width',
+  'min-width',
+  'max-width'
+]
+
 const plugins = ['stylelint-8-point-grid']
+
 const ruleName = 'plugin/8-point-grid'
+
 const messages = ruleMessages(ruleName, {
   invalid: (prop, actual, base) =>
     `Invalid \`${prop}: ${actual}\`. It should be divisible by ${base}.`
 })
 
-const pattern = props => new RegExp(props.join('|'))
+const pattern = props =>
+  new RegExp(props.map(prop => '^' + prop + '$').join('|'))
+
 const validBase = option => !isNaN(parseFloat(option)) && isFinite(option)
+
 const validWhitelist = option => hasPixelValue(option)
 
 const validPixelValue = (value, base, whitelist) => {
   return (
+    // handle multiple px values
+    //   e.g. padding: 8px 8px 1px 8px
     value
-      // Handle multiple px values
-      // e.g. padding: 8px 8px 1px 8px
-      .split(/[\s\r\n]+/)
+      .split(/ +/)
       .every(value => isWhitelist(whitelist, value) || divisibleBy(value, base))
   )
 }
 
 const hasPixelValue = value => String(value).includes('px')
+
 const isWhitelist = (whitelist, value) =>
   (whitelist && whitelist.includes(value)) || false
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const testRule = require('stylelint-test-rule-tape')
 const eightPointGrid = require('./')
 
-// Base Config
+// base config
 testRule(eightPointGrid.rule, {
   ruleName: eightPointGrid.ruleName,
   config: {
@@ -14,7 +14,9 @@ testRule(eightPointGrid.rule, {
     { code: '.generic-card { height: 100%; }' },
     { code: '.generic-card { margin: 8px 16px; }' },
     { code: '.generic-card { margin: 8px 0; }' },
-    { code: '.generic-card { margin: -64px; }' }
+    { code: '.generic-card { margin: -64px; }' },
+    // others
+    { code: '.generic-card { line-height: 4px; }' }
   ],
 
   reject: [
@@ -45,13 +47,13 @@ testRule(eightPointGrid.rule, {
   ]
 })
 
-// Extended Config
+// extended config
 testRule(eightPointGrid.rule, {
   ruleName: eightPointGrid.ruleName,
   config: {
     base: 4,
     whitelist: ['2px', '1px'],
-    ignore: ['width']
+    ignore: ['width', 'max-height', 'margin-bottom']
   },
 
   accept: [
@@ -62,7 +64,9 @@ testRule(eightPointGrid.rule, {
     { code: '.generic-card { height: 2px; }' },
     { code: '.generic-card { margin-left: 1px; }' },
     { code: '.generic-card { padding: 1px 2px 4px 4px; }' },
-    { code: '.generic-card { margin: 2px 0; }' }
+    { code: '.generic-card { margin: 2px 0; }' },
+    { code: '.generic-card { max-height: 101px; }' },
+    { code: '.generic-card { margin-bottom: 3px; }' }
   ],
 
   reject: [


### PR DESCRIPTION
- Fixes #2
- Using `/width/` regex matches a lot of css properties, 
- hardcoding blacklist seems to the best solution to avoid other css properties being matched and for flexibility